### PR TITLE
Upgrade package versions (avoid peer mismatch for react)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "rackt-cli": "^0.4.0",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "rackt-cli": "^0.6.1",
+    "react": "^15.2.1",
+    "react-dom": "^15.2.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": ">= 0.14.0",
+    "react-dom": ">= 0.14.0"
   },
   "tags": [
     "react-text-carousel"
@@ -40,7 +40,7 @@
     "text"
   ],
   "dependencies": {
-    "lodash": "^4.6.1",
+    "lodash": "^4.13.1",
     "react-typist": "0.3.0"
   }
 }


### PR DESCRIPTION
Installing the package complained about react being above 0.14 so relaxed the dependency while upgrading all the dev dependencies in the process.
