### PR TITLE
[added] loopPhrases prop [fixed] issue #4

### DIFF
--- a/lib/components/TextCarousel.js
+++ b/lib/components/TextCarousel.js
@@ -9,11 +9,13 @@ class TextCarousel extends Component {
     phrases: PropTypes.arrayOf(PropTypes.string).isRequired,
     interval: PropTypes.number,
     typistProps: PropTypes.object,
+    loopPhrases: PropTypes.boolean
   }
 
   static defaultProps = {
     interval: 2000,
     typistProps: {},
+    loopPhrases: true
   }
 
   state = {
@@ -32,8 +34,10 @@ class TextCarousel extends Component {
     const { phrases } = this.props;
     const { currentPhraseIndex } = this.state;
 
+    if(!this.props.loopPhrases && (currentPhraseIndex + 1 == phrases.length)) clearTimeout(this.timer); 
+
     this.setState({
-      currentPhraseIndex: (currentPhraseIndex + 1) % phrases.length,
+      currentPhraseIndex: this.props.loopPhrases ? (currentPhraseIndex + 1) % phrases.length : currentPhraseIndex + 1,
     });
   }
 

--- a/lib/components/TextCarousel.js
+++ b/lib/components/TextCarousel.js
@@ -34,7 +34,7 @@ class TextCarousel extends Component {
     const { phrases } = this.props;
     const { currentPhraseIndex } = this.state;
 
-    if(!this.props.loopPhrases && (currentPhraseIndex + 1 == phrases.length)) clearTimeout(this.timer); 
+    if(!this.props.loopPhrases && (currentPhraseIndex + 1 == phrases.length)) clearTimeout(this.timer);
 
     this.setState({
       currentPhraseIndex: this.props.loopPhrases ? (currentPhraseIndex + 1) % phrases.length : currentPhraseIndex + 1,
@@ -71,7 +71,7 @@ class TextCarousel extends Component {
     const customClass = this.props.className || "";
 
     return (
-      <span className={`textCarouselContainer ${customClass}}`} ref="phraseContainer" />
+      <span className={`textCarouselContainer ${customClass}`} ref="phraseContainer" />
     );
   }
 }

--- a/lib/components/TextCarousel.js
+++ b/lib/components/TextCarousel.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from 'prop-types';
 import ReactDOM from "react-dom";
 import Typist from "react-typist";
 import assign from "lodash/assign";
@@ -9,7 +10,7 @@ class TextCarousel extends Component {
     phrases: PropTypes.arrayOf(PropTypes.string).isRequired,
     interval: PropTypes.number,
     typistProps: PropTypes.object,
-    loopPhrases: PropTypes.boolean
+    loopPhrases: PropTypes.bool
   }
 
   static defaultProps = {
@@ -45,9 +46,15 @@ class TextCarousel extends Component {
     // Need the delay since typist triggers typingComplete before that happens
     const cursorHideDelay = get(this.props.typistProps, 'cursor.hideWhenDoneDelay', 0);
 
-    this.timer = setTimeout(() => {
-      this.renderWord();
-    }, this.props.interval + cursorHideDelay);
+    if (this.props.loopPhrases) {
+      this.timer = setTimeout(() => {
+        this.renderWord();
+      }, this.props.interval + cursorHideDelay);
+    } else if (this.state.currentPhraseIndex != this.props.phrases.length) {
+      this.timer = setTimeout(() => {
+        this.renderWord();
+      }, this.props.interval + cursorHideDelay);
+    }
   }
 
   getCurrentPhrase = () => this.props.phrases[this.state.currentPhraseIndex];

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   ],
   "dependencies": {
     "lodash": "^4.13.1",
-    "react-typist": "0.3.0"
+    "react-typist": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "dependencies": {
     "lodash": "^4.13.1",
+    "prop-types": "^15.5.10",
     "react-typist": "^1.1.1"
   }
 }


### PR DESCRIPTION
I'm adding a loopPhrases boolean prop that lets the plugin loop through the phrases array just once before stopping. This proves to be pretty useful when using it in a website that wants to loop through a set number of phrases before settling on a single one for the rest of the navigation.
This also solves the issues pointed out in issue #4 by removing a lone extra bracket, removes the warnings that were displayed by React when it detects the usage of the Proptypes of the main React package. Which are to be removed soon.
